### PR TITLE
added addittionall LazyLoader-information to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,65 @@ This plugin generates additional webp Thumbnails and uses is in various location
 ## After Installation
 * Download google binaries if neccessary `php bin/console frosh:webp:download-google-binaries`
 * Generate all Thumbnails new with ``php bin/console sw:thumbnail:generate -f``
+
+
+# Compatibility to LazyLoading Plugin available on Community-Store
+With small changes this Plugin is compatible with LazyLoader https://store.shopware.com/ies6685271780164/lazy-loading.html
+
+* Make change to custom/plugins/IesLazyLoading/Resources/views/frontend/listingproduct-box/box-big-image.tpl 
+* Make change to custom/plugins/IesLazyLoading/Resources/views/frontend/listingproduct-box/product-image.tpl
+* Take Care about UPDATES of LazyLoader! I will inform the Plugin developer, may be it will be added to the Plugin. - If so You'll read it here!
+
+box-big-image.tpl:
+```
+{extends file="parent:frontend/listing/product-box/box-big-image.tpl"}
+
+{block name="frontend_listing_box_article_image_picture_element"}	
+	<picture>
+        {if isset($sArticle.image.thumbnails[1].webp)}
+            <source data-srcset="{$sArticle.image.thumbnails[1].webp.sourceSet}" type="image/webp">
+        {/if}
+        <img class="lazy"
+        src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+        {if $iesLazyLoadingEffect}data-effect="{$iesLazyLoadingEffect}"{/if}
+        {if $iesLazyLoadingEffectTime}data-effectTime="{$iesLazyLoadingEffectTime}"{/if}
+        data-src="{$sArticle.image.thumbnails[1].source}"
+        data-srcset="{$sArticle.image.thumbnails[1].sourceSet}"
+        alt="{$desc}"
+        title="{$desc|truncate:160}"
+    	/>
+    </picture>
+    {block name='frontend_listing_box_article_image_picture_element_no_script'}
+        <noscript>{$smarty.block.parent}</noscript>
+    {/block}
+{/block}
+```
+
+product-image.tpl:
+```
+{extends file="parent:frontend/listing/product-box/product-image.tpl"}
+
+{block name='frontend_listing_box_article_image_picture_element'}
+    {$imageSize = $iesLazyLoadingProductImageSize}
+    {if !$imageSize}
+        {$imageSize = 0}
+    {/if}
+	<picture>
+        {if isset($sArticle.image.thumbnails[0].webp)}
+            <source data-srcset="{$sArticle.image.thumbnails[0].webp.sourceSet}" type="image/webp">
+        {/if}
+        <img class="lazy"
+        src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+        {if $iesLazyLoadingEffect}data-effect="{$iesLazyLoadingEffect}"{/if}
+        {if $iesLazyLoadingEffectTime}data-effectTime="{$iesLazyLoadingEffectTime}"{/if}
+        data-src="{$sArticle.image.thumbnails[$imageSize].source}"
+        data-srcset="{$sArticle.image.thumbnails[$imageSize].sourceSet}"
+        alt="{$desc}"
+        title="{$desc|truncate:160}"
+    	/>
+    </picture>
+    {block name='frontend_listing_box_article_image_picture_element_no_script'}
+        <noscript>{$smarty.block.parent}</noscript>
+    {/block}
+{/block}
+```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This plugin generates additional webp Thumbnails and uses is in various location
 * Generate all Thumbnails new with ``php bin/console sw:thumbnail:generate -f``
 
 
-# Compatibility to LazyLoading Plugin available on Community-Store
+## Compatibility to LazyLoading Plugin available on Community-Store
 With small changes this Plugin is compatible with LazyLoader https://store.shopware.com/ies6685271780164/lazy-loading.html
 
 * Make change to custom/plugins/IesLazyLoading/Resources/views/frontend/listingproduct-box/box-big-image.tpl 

--- a/Resources/frontend/js/jquery.last-seen-products.js
+++ b/Resources/frontend/js/jquery.last-seen-products.js
@@ -2,7 +2,7 @@ $.subscribe('plugin/swLastSeenProducts/onCreateProductImage', function (_, _, el
     if (data.images[0].sourceSetWebP) {
         var imageElement = element.find('.image--element');
         var content = imageElement.find('.image--media').html();
-        var webPTag = '<source srcset="' + data.images[0].sourceSetWebP + '" type="image/webp">';
+        var webPTag = '<source srcset="' + data.images[0].sourceSetWebP + '" data-srcset="' + data.images[0].sourceSetWebP + '" type="image/webp">';
 
         content = '<picture>' + webPTag + content + '</picture>';
 

--- a/Resources/frontend/js/jquery.last-seen-products.js
+++ b/Resources/frontend/js/jquery.last-seen-products.js
@@ -1,6 +1,6 @@
 $.subscribe('plugin/swLastSeenProducts/onCreateProductImage', function (_, _, element, data) {
     if (data.images[0].sourceSetWebP) {
-        var imageElement = element.find('.image--media');
+        var imageElement = element.find('.image--element');
         var content = imageElement.find('.image--media').html();
         var webPTag = '<source srcset="' + data.images[0].sourceSetWebP + '" type="image/webp">';
 


### PR DESCRIPTION
as WebP works with small changes with the Available LazyLoader from the community-store i added inforamtion on this.

The Plugin uses lazysize ( https://github.com/aFarkas/lazysizes ) and looks good so far, so i saw no need to do the same ;-D