### PR TITLE
Enhance img tags with lazy loading

### DIFF
--- a/Resources/views/frontend/blog/box.tpl
+++ b/Resources/views/frontend/blog/box.tpl
@@ -11,12 +11,12 @@
                         {if isset($sArticle.media.thumbnails[0].webp)}
                             <source srcset="{$sArticle.media.thumbnails[0].webp.sourceSet}" type="image/webp">
                         {/if}
-                        <img srcset="{$sArticle.media.thumbnails[0].sourceSet}"
+                        <img loading="lazy" srcset="{$sArticle.media.thumbnails[0].sourceSet}"
                              alt="{$sArticle.title|escape}"
                              title="{$sArticle.title|escape|truncate:160}" />
                     </picture>
                 {else}
-                    <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
+                    <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}"
                          alt="{$sArticle.title|escape}"
                          title="{$sArticle.title|escape|truncate:160}" />
                 {/if}

--- a/Resources/views/frontend/blog/images.tpl
+++ b/Resources/views/frontend/blog/images.tpl
@@ -18,7 +18,7 @@
                 {if isset($sArticle.preview.thumbnails[1].webp)}
                     <source srcset="{$sArticle.preview.thumbnails[1].webp.sourceSet}" type="image/webp">
                 {/if}
-                <img srcset="{$sArticle.preview.thumbnails[1].sourceSet}"
+                <img loading="lazy" srcset="{$sArticle.preview.thumbnails[1].sourceSet}"
                      src="{$sArticle.preview.thumbnails[1].source}"
                      class="blog--image panel has--border is--rounded"
                      alt="{$alt}"
@@ -49,7 +49,7 @@
                         {if isset($sArticleMedia.thumbnails[0].webp)}
                             <source srcset="{$sArticleMedia.thumbnails[0].webp.sourceSet}" type="image/webp">
                         {/if}
-                        <img srcset="{$sArticleMedia.thumbnails[0].sourceSet}"
+                        <img loading="lazy" srcset="{$sArticleMedia.thumbnails[0].sourceSet}"
                              class="blog--thumbnail-image"
                              alt="{s name="BlogThumbnailText" namespace="frontend/blog/detail"}{/s}: {$alt}"
                              title="{s name="BlogThumbnailText" namespace="frontend/blog/detail"}{/s}: {$alt|truncate:160}" />

--- a/Resources/views/frontend/checkout/ajax_add_article.tpl
+++ b/Resources/views/frontend/checkout/ajax_add_article.tpl
@@ -17,10 +17,10 @@
                     {if isset($image.thumbnails[0].webp)}
                         <source srcset="{$image.thumbnails[0].webp.sourceSet}" type="image/webp">
                     {/if}
-                    <img srcset="{$image.thumbnails[0].sourceSet}" alt="{$alt}" title="{$alt|truncate:160}" />
+                    <img loading="lazy" srcset="{$image.thumbnails[0].sourceSet}" alt="{$alt}" title="{$alt|truncate:160}" />
                 {else}
                     {block name='frontend_detail_image_fallback'}
-                        <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" title="{$alt|truncate:160}" />
+                        <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" title="{$alt|truncate:160}" />
                     {/block}
                 {/if}
             </span>

--- a/Resources/views/frontend/compare/col.tpl
+++ b/Resources/views/frontend/compare/col.tpl
@@ -17,11 +17,11 @@
                     {if isset($sArticle.image.thumbnails[0].webp)}
                         <source srcset="{$sArticle.image.thumbnails[0].webp.sourceSet}" alt="{$desc|strip_tags|truncate:160}" type="image/webp"/>
                     {/if}
-                        <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
+                        <img loading="lazy" srcset="{$sArticle.image.thumbnails[0].sourceSet}"
                              alt="{$desc}"
                              title="{$desc|truncate:160}" />
                     {else}
-                        <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
+                        <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}"
                              alt="{$desc}"
                              title="{$desc|truncate:160}" />
                     {/if}

--- a/Resources/views/frontend/detail/config_variant.tpl
+++ b/Resources/views/frontend/detail/config_variant.tpl
@@ -7,9 +7,9 @@
         {if isset($media.thumbnails[0].webp)}
             <source srcset="{$media.thumbnails[0].webp.sourceSet}" type="image/webp">
         {/if}
-        <img srcset="{$media.thumbnails[0].sourceSet}" alt="{$option.optionname}"/>
+        <img loading="lazy" srcset="{$media.thumbnails[0].sourceSet}" alt="{$option.optionname}"/>
     {else}
-        <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$option.optionname}">
+        <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$option.optionname}">
     {/if}
     </span>
 </span>

--- a/Resources/views/frontend/detail/image.tpl
+++ b/Resources/views/frontend/detail/image.tpl
@@ -26,7 +26,7 @@
                             {if isset($sArticle.image.thumbnails[1].webp)}
                                 <source srcset="{$sArticle.image.thumbnails[1].webp.sourceSet}" type="image/webp">
                             {/if}
-                            <img srcset="{$sArticle.image.thumbnails[1].sourceSet}"
+                            <img loading="lazy" srcset="{$sArticle.image.thumbnails[1].sourceSet}"
                                  src="{$sArticle.image.thumbnails[1].source}"
                                  alt="{$alt}"
                                  itemprop="image" />
@@ -34,7 +34,7 @@
                     {/block}
                 {else}
                     {block name='frontend_detail_image_fallback'}
-                    <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" itemprop="image" />
+                    <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" itemprop="image" />
                 {/block}
                 {/if}
             </span>
@@ -47,6 +47,6 @@
         {if isset($image.thumbnails[1].webp)}
             <source srcset="{$image.thumbnails[1].webp.sourceSet}" type="image/webp">
         {/if}
-        <img srcset="{$image.thumbnails[1].sourceSet}" alt="{$alt}" itemprop="image" />
+        <img loading="lazy" srcset="{$image.thumbnails[1].sourceSet}" alt="{$alt}" itemprop="image" />
     </picture>
 {/block}

--- a/Resources/views/frontend/detail/images.tpl
+++ b/Resources/views/frontend/detail/images.tpl
@@ -5,7 +5,7 @@
         {if isset($sArticle.image.thumbnails[0].webp)}
             <source srcset="{$sArticle.image.thumbnails[0].webp.sourceSet}" type="image/webp">
         {/if}
-        <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
+        <img loading="lazy" srcset="{$sArticle.image.thumbnails[0].sourceSet}"
              alt="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
              title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:160}"
              class="thumbnail--image" />
@@ -17,7 +17,7 @@
         {if isset($image.thumbnails[0].webp)}
             <source srcset="{$image.thumbnails[0].webp.sourceSet}" type="image/webp">
         {/if}
-        <img srcset="{$image.thumbnails[0].sourceSet}"
+        <img loading="lazy" srcset="{$image.thumbnails[0].sourceSet}"
              alt="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
              title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:160}"
              class="thumbnail--image" />

--- a/Resources/views/frontend/index/logo-container.tpl
+++ b/Resources/views/frontend/index/logo-container.tpl
@@ -26,7 +26,7 @@
                     <source srcset="{link file=$theme.mobileLogoWebp}" type="image/webp">
                 {/if}
 
-                <img srcset="{link file=$theme.mobileLogo}" alt="{"{config name=shopName}"|escapeHtml} - {"{s name='IndexLinkDefault' namespace="frontend/index/index"}{/s}"|escape}" />
+                <img loading="lazy" srcset="{link file=$theme.mobileLogo}" alt="{"{config name=shopName}"|escapeHtml} - {"{s name='IndexLinkDefault' namespace="frontend/index/index"}{/s}"|escape}" />
             </picture>
         </a>
     </div>

--- a/Resources/views/frontend/listing/banner.tpl
+++ b/Resources/views/frontend/listing/banner.tpl
@@ -8,7 +8,7 @@
         {/if}
         <source srcset="{$sBanner.media.thumbnails[1].sourceSet}" media="(min-width: 48em)">
 
-        <img srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escape}" class="banner--img" />
+        <img loading="lazy" srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escape}" class="banner--img" />
     </picture>
 {/block}
 
@@ -22,7 +22,7 @@
 
             <source srcset="{$sBanner.media.thumbnails[1].sourceSet}" media="(min-width: 48em)">
 
-            <img srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escape}" class="banner--img" />
+            <img loading="lazy" srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escape}" class="banner--img" />
         </picture>
     </a>
 {/block}

--- a/Resources/views/frontend/listing/product-box/box-big-image.tpl
+++ b/Resources/views/frontend/listing/product-box/box-big-image.tpl
@@ -6,7 +6,7 @@
         {if isset($sArticle.image.thumbnails[1].webp)}
             <source srcset="{$sArticle.image.thumbnails[1].webp.sourceSet}" type="image/webp">
         {/if}
-        <img srcset="{$sArticle.image.thumbnails[1].sourceSet}"
+        <img loading="lazy" srcset="{$sArticle.image.thumbnails[1].sourceSet}"
              alt="{$desc}"
              title="{$desc|truncate:160}"/>
     </picture>

--- a/Resources/views/frontend/listing/product-box/box-emotion.tpl
+++ b/Resources/views/frontend/listing/product-box/box-emotion.tpl
@@ -61,14 +61,14 @@
     {if isset($sArticle.image.thumbnails[0].webp)}
         <source srcset="{$sArticle.image.thumbnails[0].webp.source}" alt="{$desc|strip_tags|truncate:160}" type="image/webp"/>
     {/if}
-        <img src="{$sArticle.image.thumbnails[0].source}" alt="{$desc|strip_tags|truncate:160}" />
+        <img loading="lazy" src="{$sArticle.image.thumbnails[0].source}" alt="{$desc|strip_tags|truncate:160}" />
 
         </picture>
 
     {elseif $sArticle.image.source}
-        <img src="{$sArticle.image.webp.source}" alt="{$desc|strip_tags|truncate:160}" type="image/webp"/>
-        <img src="{$sArticle.image.source}" alt="{$desc|strip_tags|truncate:160}" />
+        <img loading="lazy" src="{$sArticle.image.webp.source}" alt="{$desc|strip_tags|truncate:160}" type="image/webp"/>
+        <img loading="lazy" src="{$sArticle.image.source}" alt="{$desc|strip_tags|truncate:160}" />
     {else}
-        <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$desc|strip_tags|truncate:160}" />
+        <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$desc|strip_tags|truncate:160}" />
     {/if}
 {/block}

--- a/Resources/views/frontend/listing/product-box/product-image.tpl
+++ b/Resources/views/frontend/listing/product-box/product-image.tpl
@@ -6,7 +6,7 @@
         {if isset($sArticle.image.thumbnails[0].webp)}
             <source srcset="{$sArticle.image.thumbnails[0].webp.sourceSet}" type="image/webp">
         {/if}
-        <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
+        <img loading="lazy" srcset="{$sArticle.image.thumbnails[0].sourceSet}"
              alt="{$desc}"
              title="{$desc|truncate:160}" />
     </picture>

--- a/Resources/views/widgets/emotion/components/component_banner.tpl
+++ b/Resources/views/widgets/emotion/components/component_banner.tpl
@@ -43,6 +43,6 @@
         <source sizes="{$itemSize}" srcset="{$srcSet}">
 
         {* Fallback *}
-        <img src="{$baseSource}" srcset="{$retinaBaseSource} 2x" class="banner--image-src"{if $Data.title} alt="{$Data.title|escape}"{/if} />
+        <img loading="lazy" src="{$baseSource}" srcset="{$retinaBaseSource} 2x" class="banner--image-src"{if $Data.title} alt="{$Data.title|escape}"{/if} />
     </picture>
 {/block}

--- a/Resources/views/widgets/emotion/components/component_banner_slider.tpl
+++ b/Resources/views/widgets/emotion/components/component_banner_slider.tpl
@@ -41,7 +41,7 @@
         {if $srcSetWebP}
             <source srcset="{$srcSetWebP}" sizes="{$itemSize}" type="image/webp">
         {/if}
-        <img src="{$baseSource}"
+        <img loading="lazy" src="{$baseSource}"
              class="banner-slider--image"
              {if $srcSet}sizes="{$itemSize}" srcset="{$srcSet}"{/if}
                 {if $banner.altText}alt="{$banner.altText|escape}" {/if}/>

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,158 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a5d70c94344c827d5692f485f0ba8b9f",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.6"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
         xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Webp Unterstützung</label>
     <label lang="en">Webp Support</label>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <copyright>Friends of Shopware</copyright>
     <license>MIT</license>
     <link>https://friendsofshopware.github.io/</link>
@@ -93,6 +93,15 @@
             - Webp-Bild laden, während in das Bild gezoomt wird
             - Unterstützung für Kategorie-Teaser hinzugefügt, dank @DeverNet
             - SVG-Bilder ignorieren
+        </changes>
+    </changelog>
+
+    <changelog version="1.1.2">
+        <changes lang="en">
+            - Add lazy loading to img tags
+        </changes>
+        <changes lang="de">
+            - Lazy loading zu den img Tags hinzugefügt
         </changes>
     </changelog>
 </plugin>


### PR DESCRIPTION
We added `loading="lazy"` to all img tags in the plugin. 
We did so following this article on [web.dev about lazy loding](https://web.dev/browser-level-image-lazy-loading/)

Quoting from this article:

> **Why browser-level lazy-loading?**
> According to HTTPArchive, images are the most requested asset type for most websites and usually take up more 
> bandwidth than any other resource. At the 90th percentile, sites send about 4.7 MB of images on desktop and mobile.
> That's a lot of cat pictures.

> **Browser compatibility**
> <img loading=lazy> is supported by most popular Chromium-powered browsers (Chrome, Edge, Opera) and Firefox. The 
> implementation for WebKit (Safari) is in progress. caniuse.com has detailed information on cross-browser support.
> Browsers that do not support the loading attribute simply ignore it without side-effects.

We sucessfully applied this change to our shopware instance and increased the initial loading speed of our product pages. For us, it is a major benefit to our mobile clients user experience.
