### PR TITLE
fix component banner tpl

### DIFF
--- a/Resources/views/widgets/emotion/components/component_banner.tpl
+++ b/Resources/views/widgets/emotion/components/component_banner.tpl
@@ -43,6 +43,6 @@
         <source sizes="{$itemSize}" srcset="{$srcSet}">
 
         {* Fallback *}
-        <img loading="lazy" src="{$baseSource}" srcset="{$retinaBaseSource} 2x" class="banner--image-src"{if $Data.title} alt="{$Data.title|escape}"{/if} />
+        <img loading="lazy" src="{$baseSource}" {if $retinaBaseSource}srcset="{$retinaBaseSource} 2x"{/if} class="banner--image-src"{if $Data.title} alt="{$Data.title|escape}"{/if} />
     </picture>
 {/block}


### PR DESCRIPTION
This PR fix the tpl for the emotion banner component, if no retina image is set.

This change is the same, like in the shopware repo.
https://github.com/shopware/shopware/blob/5.7/themes/Frontend/Bare/widgets/emotion/components/component_banner.tpl