### PR TITLE
Add missing picture tag

### DIFF
--- a/Resources/views/frontend/checkout/ajax_add_article.tpl
+++ b/Resources/views/frontend/checkout/ajax_add_article.tpl
@@ -13,16 +13,18 @@
             {/if}
 
             <span class="image--media">
-                {if isset($image.thumbnails)}
-                    {if isset($image.thumbnails[0].webp)}
-                        <source srcset="{$image.thumbnails[0].webp.sourceSet}" type="image/webp">
+                <picture>
+                    {if isset($image.thumbnails)}
+                        {if isset($image.thumbnails[0].webp)}
+                            <source srcset="{$image.thumbnails[0].webp.sourceSet}" type="image/webp">
+                        {/if}
+                        <img loading="lazy" srcset="{$image.thumbnails[0].sourceSet}" alt="{$alt}" title="{$alt|truncate:160}" />
+                    {else}
+                        {block name='frontend_detail_image_fallback'}
+                            <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" title="{$alt|truncate:160}" />
+                        {/block}
                     {/if}
-                    <img loading="lazy" srcset="{$image.thumbnails[0].sourceSet}" alt="{$alt}" title="{$alt|truncate:160}" />
-                {else}
-                    {block name='frontend_detail_image_fallback'}
-                        <img loading="lazy" src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" title="{$alt|truncate:160}" />
-                    {/block}
-                {/if}
+                </picture>
             </span>
         </a>
     </div>


### PR DESCRIPTION
According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source) a source tag musst have on of the following parent elements:

- audio
- video
- track
- picture

Since it was missing here i added it.